### PR TITLE
Support python3.9+

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -5,7 +5,7 @@
 
 """
 import sys
-from collections import Mapping, MutableMapping
+from collections.abc import Mapping, MutableMapping
 from datetime import timedelta
 from inspect import getargspec
 

--- a/configure.py
+++ b/configure.py
@@ -5,7 +5,10 @@
 
 """
 import sys
-from collections.abc import Mapping, MutableMapping
+try:
+    from collections.abc import Mapping, MutableMapping
+except ImportError:
+    from collections import Mapping, MutableMapping
 from datetime import timedelta
 from inspect import getargspec
 


### PR DESCRIPTION
From python 3.9 onwards Mapping and MutableMapping modules are moved into collections.abc
ref - https://docs.python.org/3/library/collections.abc.html